### PR TITLE
Default saturation 1.2 for accent source

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: ericdahl-dev
 pkgname=omarchy-wled
-pkgver=0.1.1
+pkgver=0.1.2
 pkgrel=1
 pkgdesc="Sync Omarchy theme accent or wallpaper color to a WLED device"
 arch=('any')

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ omarchy-wled <WLED_IP> [options]
 Options:
   --source {accent,fg,bg}  Color source: accent (default), fg (foreground), or bg (wallpaper average)
   -b, --brightness 0-255   LED brightness (default 255)
-  -s, --saturation SCALE   Saturation multiplier (0.0=greyscale, 1.0=unchanged, >1.0=boost, default 1.0)
+  -s, --saturation SCALE   Saturation multiplier (0.0=greyscale, 1.0=unchanged, >1.0=boost; default 1.2 for accent, 1.0 for fg/bg)
   --once                   Send once and exit
 ```
 
@@ -42,7 +42,7 @@ omarchy-wled 192.168.1.50 --source fg
 # Use wallpaper average color at 80% brightness
 omarchy-wled 192.168.1.50 --source bg -b 200
 
-# Boost saturation
+# Boost saturation (accent already defaults to 1.2)
 omarchy-wled 192.168.1.50 -s 1.5
 
 # Send once and exit

--- a/omarchy_wled.py
+++ b/omarchy_wled.py
@@ -266,8 +266,8 @@ def main() -> None:
         help="Color source: accent (theme accent color) or bg (wallpaper average, requires Pillow)"
     )
     parser.add_argument(
-        "-s", "--saturation", type=float, default=1.0, metavar="SCALE",
-        help="Saturation multiplier (0.0=greyscale, 1.0=unchanged, >1.0=boost, default 1.0)"
+        "-s", "--saturation", type=float, default=None, metavar="SCALE",
+        help="Saturation multiplier (0.0=greyscale, 1.0=unchanged, >1.0=boost, default 1.2 for accent, 1.0 otherwise)"
     )
     parser.add_argument(
         "-b", "--brightness", type=int, default=255, metavar="0-255",
@@ -278,6 +278,9 @@ def main() -> None:
         help="Send current color once and exit (no watching)"
     )
     args = parser.parse_args()
+
+    if args.saturation is None:
+        args.saturation = 1.2 if args.source == "accent" else 1.0
 
     source = make_source(args.source)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "omarchy-wled"
-version = "0.1.1"
+version = "0.1.2"
 description = "Sync Omarchy theme accent or wallpaper color to a WLED device"
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary

- Accent source defaults to `--saturation 1.2` — more vivid on WLED without affecting fg/bg
- `fg`/`bg` unchanged (default `1.0`)
- Still overridable via `-s`
- README updated
- Bump to 0.1.2

💘 Generated with Crush