### PR TITLE
chore(release): bump PKGBUILD to 0.3.0

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: ericdahl-dev
 pkgname=omarchy-wled
-pkgver=0.2.2
+pkgver=0.3.0
 pkgrel=1
 pkgdesc="Sync Omarchy theme accent or wallpaper color to a WLED device"
 arch=('x86_64' 'aarch64')


### PR DESCRIPTION
Prepare **v0.3.0** release (gradient_sample average vs row). After merge, tag `v0.3.0` to trigger GitHub Release + AUR workflow.